### PR TITLE
MDL-77917 Add version support

### DIFF
--- a/application/src/Controller/MatrixController.php
+++ b/application/src/Controller/MatrixController.php
@@ -21,11 +21,65 @@ use Symfony\Component\HttpFoundation\Request;
  * @Route("/{serverID}/_matrix/client")
  */
 class MatrixController extends AbstractController {
+    use GeneralTrait;
+    use MatrixSynapseTrait;
 
-    use GeneralTrait, MatrixSynapseTrait;
+    /**
+     * @Route("/versions", name="versions")
+     */
+    public function versions(): JsonResponse
+    {
+        return new JsonResponse((object) [
+            "versions" => [
+                "r0.0.1",
+                "r0.1.0",
+                "r0.2.0",
+                "r0.3.0",
+                "r0.4.0",
+                "r0.5.0",
+                "r0.6.0",
+                "r0.6.1",
+                "v1.1",
+                "v1.2",
+                "v1.3",
+                "v1.4",
+                "v1.5",
+                "v1.6",
+            ],
+            "unstable_features"=> [
+                "org.matrix.label_based_filtering" => true,
+                "org.matrix.e2e_cross_signing" => true,
+                "org.matrix.msc2432" => true,
+                "uk.half-shot.msc2666.query_mutual_rooms" => true,
+                "io.element.e2ee_forced.public" => false,
+                "io.element.e2ee_forced.private" => false,
+                "io.element.e2ee_forced.trusted_private" => false,
+                "org.matrix.msc3026.busy_presence" => false,
+                "org.matrix.msc2285.stable" => true,
+                "org.matrix.msc3827.stable" => true,
+                "org.matrix.msc2716" => false,
+                "org.matrix.msc3440.stable" => true,
+                "org.matrix.msc3771" => true,
+                "org.matrix.msc3773" => false,
+                "fi.mau.msc2815" => false,
+                "fi.mau.msc2659.stable" => true,
+                "org.matrix.msc3882" => false,
+                "org.matrix.msc3881" => false,
+                "org.matrix.msc3874" => false,
+                "org.matrix.msc3886" => false,
+                "org.matrix.msc3912" => false,
+                "org.matrix.msc3952_intentional_mentions" => false,
+                "org.matrix.msc3981" => false,
+                "org.matrix.msc3391" => false,
+            ]
+        ]);
+    }
 
     /**
      * @Route("/r0", name="endpoint")
+     * @Route("/v1", name="endpoint")
+     * @Route("/v2", name="endpoint")
+     * @Route("/v3", name="endpoint")
      */
     public function endpoint(): JsonResponse
     {
@@ -43,7 +97,7 @@ class MatrixController extends AbstractController {
      * @param Request $request
      * @return JsonResponse
      */
-    public function login(string $serverID, Request $request) : JsonResponse {
+    public function login(string $serverID, Request $request): JsonResponse {
         // 1. Check HTTP method is accepted.
         $accessCheck = $this->authHttpCheck(['POST'], $request, false);
         if (!$accessCheck['status']) {
@@ -129,7 +183,7 @@ class MatrixController extends AbstractController {
      * @param Request $request
      * @return JsonResponse
      */
-    public function refresh(string $serverID, Request $request) : JsonResponse {
+    public function refresh(string $serverID, Request $request):JsonResponse {
         // 1. Check HTTP method is accepted.
         $accessCheck = $this->authHttpCheck(['POST'], $request, false);
         if (!$accessCheck['status']) {
@@ -168,11 +222,12 @@ class MatrixController extends AbstractController {
      * Create Matrix room.
      *
      * @Route("/r0/createRoom", name="createRoom")
+     * @Route("/v3/createRoom", name="createRoom")
      * @param string $serverID
      * @param Request $request
      * @return JsonResponse
      */
-    public function createRoom(string $serverID, Request $request) : JsonResponse {
+    public function createRoom(string $serverID, Request $request):JsonResponse {
         // 1. Check call auth.
         // 2. Check HTTP method is accepted.
         $accessCheck = $this->authHttpCheck(['POST'], $request);
@@ -221,10 +276,11 @@ class MatrixController extends AbstractController {
      * Create Matrix room.
      *
      * @Route("/r0/rooms/{roomID}/kick", name="kick")
+     * @Route("/v3/rooms/{roomID}/kick", name="kick")
      * @param Request $request
      * @return JsonResponse
      */
-    public function kick(string $roomID, Request $request) : JsonResponse {
+    public function kick(string $roomID, Request $request):JsonResponse {
         // 1. Check call auth.
         // 2. Check HTTP method is accepted.
         $accessCheck = $this->authHttpCheck(['POST'], $request);
@@ -267,12 +323,14 @@ class MatrixController extends AbstractController {
      *
      * @Route("/r0/rooms/{roomID}/state/{eventType}")
      * @Route("/r0/rooms/{roomID}/state/{eventType}/")
+     * @Route("/v3/rooms/{roomID}/state/{eventType}")
+     * @Route("/v3/rooms/{roomID}/state/{eventType}/")
      * @param string $serverID
      * @param string $eventType
      * @param Request $request
      * @return JsonResponse
      */
-    public function roomState(string $serverID, string $roomID, string $eventType, Request $request) : JsonResponse {
+    public function roomState(string $serverID, string $roomID, string $eventType, Request $request):JsonResponse {
         // 1. Check call auth.
         // 2. Check HTTP method is accepted.
         $accessCheck = $this->authHttpCheck(['PUT'], $request);
@@ -335,12 +393,13 @@ class MatrixController extends AbstractController {
      * Gets all joined members of a group.
      *
      * @Route("/r0/rooms/{roomID}/joined_members", name="getJoinedMembers")
+     * @Route("/v3/rooms/{roomID}/joined_members", name="getJoinedMembers")
      * @param string $serverID
      * @param string $roomID
      * @param Request $request
      * @return JsonResponse
      */
-    public function getJoinedMembers(string $serverID, string $roomID, Request $request) : JsonResponse {
+    public function getJoinedMembers(string $serverID, string $roomID, Request $request):JsonResponse {
         // 1. Check call auth.
         // 2. Check HTTP method is accepted.
         $accessCheck = $this->authHttpCheck(['GET'], $request);

--- a/application/src/Controller/MediaController.php
+++ b/application/src/Controller/MediaController.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\File\File;
 /**
  * API Controller to serve a mock of the Matrix API for media requests.
  *
- * @Route("/{serverID}/_matrix/media/r0")
+ * @Route("/{serverID}/_matrix/media")
  */
 class MediaController extends AbstractController {
 
@@ -35,8 +35,10 @@ class MediaController extends AbstractController {
     /**
      * Create Matrix room.
      *
-     * @Route("/upload")
-     * @Route("/upload/")
+     * @Route("/r0/upload")
+     * @Route("/r0/upload/")
+     * @Route("/v3/upload")
+     * @Route("/v3/upload/")
      * @param string $serverID
      * @param Request $request
      * @return JsonResponse

--- a/application/src/Controller/SynapseController.php
+++ b/application/src/Controller/SynapseController.php
@@ -27,7 +27,7 @@ class SynapseController extends AbstractController {
     /**
      * @Route("/v2", name="endpoint")
      */
-    public function endpoint() : JsonResponse
+    public function endpoint(): JsonResponse
     {
         return new JsonResponse((object) [
             'errcode' => 'M_UNRECOGNIZED',
@@ -43,7 +43,7 @@ class SynapseController extends AbstractController {
      * @param Request $request
      * @return JsonResponse
      */
-    public function registerUser(string $serverID, string $userID, Request $request) : JsonResponse
+    public function registerUser(string $serverID, string $userID, Request $request): JsonResponse
     {
         // 1. Check call auth.
         // 2. Check HTTP method is accepted.
@@ -105,7 +105,7 @@ class SynapseController extends AbstractController {
      * @param Request $request
      * @return JsonResponse
      */
-    private function createUser(string $serverID, string $userID, Request $request) : JsonResponse
+    private function createUser(string $serverID, string $userID, Request $request): JsonResponse
     {
         $user = new Users();
         return $this->upsertUser($serverID, $userID, $request, $user);
@@ -119,7 +119,7 @@ class SynapseController extends AbstractController {
      * @param Request $request
      * @return JsonResponse
      */
-    private function updateUser(string $serverID, string $userID, Request $request, Users $user) : JsonResponse
+    private function updateUser(string $serverID, string $userID, Request $request, Users $user): JsonResponse
     {
         return $this->upsertUser($serverID, $userID, $request, $user, 200);
     }
@@ -133,7 +133,7 @@ class SynapseController extends AbstractController {
      * @param Request $request
      * @return JsonResponse
      */
-    private function upsertUser(string $serverID, string $userID, Request $request, Users $user, int $status = 201) : JsonResponse
+    private function upsertUser(string $serverID, string $userID, Request $request, Users $user, int $status = 201): JsonResponse
     {
         $payload = json_decode($request->getContent());
         $entityManager = $this->getDoctrine()->getManager();
@@ -249,7 +249,7 @@ class SynapseController extends AbstractController {
      * @param Request $request
      * @return JsonResponse
      */
-    public function inviteUser(string $serverID, string $roomID, Request $request) : JsonResponse {
+    public function inviteUser(string $serverID, string $roomID, Request $request): JsonResponse {
         // 1. Check call auth.
         // 2. Check HTTP method is accepted.
         $accessCheck = $this->authHttpCheck(['POST'], $request);
@@ -308,7 +308,7 @@ class SynapseController extends AbstractController {
      * @param Request $request
      * @return JsonResponse
      */
-    public function deleteRoom(string $serverID, string $roomID, Request $request) : JsonResponse {
+    public function deleteRoom(string $serverID, string $roomID, Request $request): JsonResponse {
         // 1. Check call auth.
         // 2. Check HTTP method is accepted.
         $accessCheck = $this->authHttpCheck(['DELETE'], $request, false);
@@ -346,7 +346,7 @@ class SynapseController extends AbstractController {
      * @param Request $request
      * @return JsonResponse
      */
-    public function roomInfo(string $serverID, string $roomID, Request $request) : JsonResponse {
+    public function roomInfo(string $serverID, string $roomID, Request $request): JsonResponse {
         // 1. Check call auth.
         // 2. Check HTTP method is accepted.
         $accessCheck = $this->authHttpCheck(['GET'], $request);


### PR DESCRIPTION
This change adds support for Matrix server versions per the specification.

https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientversions

This also updates in-use URLs to use the correct version endpoint. Previously we were only offering the `r0` endpoint for many, but that versioning is no longer used.