### PR TITLE
Reduce flushing (performance)

### DIFF
--- a/application/src/Controller/BackOfficeController.php
+++ b/application/src/Controller/BackOfficeController.php
@@ -119,9 +119,9 @@ class BackOfficeController extends AbstractController {
                 ->findBy(['serverid' => $serverID]);
             foreach ($entities as $entity) {
                 $entityManager->remove($entity);
-                $entityManager->flush();
             }
         }
+        $entityManager->flush();
 
         return new JsonResponse((object) ['reset' => true]);
     }

--- a/application/src/Controller/SynapseController.php
+++ b/application/src/Controller/SynapseController.php
@@ -322,7 +322,6 @@ class SynapseController extends AbstractController {
                 ->findBy(['serverid' => $serverID, 'roomid' => $roomID]);
         foreach ($roommembers as $entity) {
             $entityManager->remove($entity);
-            $entityManager->flush();
         }
 
         $room = $this->getDoctrine()
@@ -330,8 +329,8 @@ class SynapseController extends AbstractController {
                 ->findBy(['roomid' => $roomID]);
         if (!empty($room)) {
             $entityManager->remove($room[0]);
-            $entityManager->flush();
         }
+        $entityManager->flush();
 
         return new JsonResponse((object) [
             'delete_id' => substr(hash('sha256', (date("Ymdhms"))), 0, 18)


### PR DESCRIPTION
We do not need to flush in a loop. Persisting a change causes that to be stored in the in-memory model already.