### PR TITLE
MDL-79460: Add support for powerlevels and route for sync

### DIFF
--- a/application/src/Entity/RoomMember.php
+++ b/application/src/Entity/RoomMember.php
@@ -56,6 +56,11 @@ class RoomMember
      */
     private $state;
 
+    /**
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    private $powerlevel;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -151,6 +156,18 @@ class RoomMember
     public function setState(string $state = null): self
     {
         $this->state = $state;
+
+        return $this;
+    }
+
+    public function getPowerLevel(): ?int
+    {
+        return $this->powerlevel;
+    }
+
+    public function setPowerLevel(int $powerlevel): self
+    {
+        $this->powerlevel = $powerlevel;
 
         return $this;
     }

--- a/application/src/Service/Filter.php
+++ b/application/src/Service/Filter.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Service;
+
+use App\Service\Filter\RoomFilter;
+use Symfony\Component\HttpFoundation\Request;
+
+
+class Filter
+{
+    private array $roomIds = [];
+    private RoomFilter $roomFilter;
+
+    public static function fromRequest(Request $request): static
+    {
+        $filter = new static();
+
+        $filterData = $request->query->get('filter');
+        if (!$filterData) {
+            return $filter;
+        }
+
+        // Filter the event data according to the API:
+        // https://spec.matrix.org/v1.1/client-server-api/#filtering
+        // Filters are made up of different filter types.
+        // Detailed here: https://spec.matrix.org/v1.1/client-server-api/#post_matrixclientv3useruseridfilter
+        $filterData = json_decode($request->query->get('filter'));
+
+        if (property_exists($filterData, 'room')) {
+            $filter->setRoomFilter(RoomFilter::fromObject($filterData->room));
+        }
+
+        return $filter;
+    }
+
+    public function setRoomFilter(RoomFilter $roomFilter): static
+    {
+        $this->roomFilter = $roomFilter;
+        return $this;
+    }
+
+    public function getRequestedRoomIds(): array
+    {
+        return $this->roomIds;
+    }
+
+    public function getRoomFilter(): RoomFilter
+    {
+        if (empty($this->roomFilter)) {
+            $this->roomFilter = new RoomFilter();
+        }
+
+        return $this->roomFilter;
+    }
+}

--- a/application/src/Service/RoomFilter.php
+++ b/application/src/Service/RoomFilter.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Service\Filter;
+
+class RoomFilter
+{
+    private array $roomIds = [];
+    private StateFilter $roomStateFilter;
+
+    public static function fromObject(\stdClass $filterData): static
+    {
+        $filter = new static();
+
+        // Check for a list of rooms.
+        if (property_exists($filterData, 'rooms')) {
+            $rooms = (array) $filterData->rooms;
+            $filter->setRoomIds($rooms);
+        }
+
+        // Check for a room state filter.
+        if (property_exists($filterData, 'state')) {
+            $filter->setRoomState(StateFilter::fromObject($filterData->state));
+        }
+
+        return $filter;
+    }
+
+    public function setRoomIds(array $ids): static
+    {
+        $this->roomIds = $ids;
+        return $this;
+    }
+
+    public function setRoomState(StateFilter $state): static
+    {
+        $this->roomStateFilter = $state;
+        return $this;
+    }
+
+    public function getRoomIds(): array
+    {
+        return $this->roomIds;
+    }
+
+    public function getRoomState(): StateFilter
+    {
+        return $this->roomStateFilter;
+    }
+}

--- a/application/src/Service/StateFilter.php
+++ b/application/src/Service/StateFilter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Service\Filter;
+
+class StateFilter
+{
+    private array $types = [];
+
+    public static function fromObject(\stdClass $filterData): static
+    {
+        $filter = new static();
+
+        // We currently only support types.
+        if (property_exists($filterData, 'types')) {
+            $types = (array) $filterData->types;
+            $filter->setTypes($types);
+        }
+
+        return $filter;
+    }
+
+    public function setTypes(array $types): static
+    {
+        $this->types = $types;
+        return $this;
+    }
+
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+}


### PR DESCRIPTION
I have added a new route for /v3/sync. This commit allows certain behat and phpunit tests to function again. See MDL-79460 for more info.

There is also some power level approximation going on in there for students, teachers and admins. This will let Matrix assign them the equivalent power level that Moodle uses based on roles by checking the Matrix username used.

There is a noticeable downside to doing this. If a user who has the username of @teacher123, they will be assigned the powerlevel of 51, but if they are demoted, or even promoted, their powerlevel will be set back to what the username indicates it should be.