### PR TITLE
MDL-80832: Fix users param formatting from getPowerLevelState

### DIFF
--- a/application/src/Entity/Room.php
+++ b/application/src/Entity/Room.php
@@ -229,9 +229,9 @@ class Room
         });
 
         // Build the power level state.
-        $memberInfo = $members->map(fn(RoomMember $member) => [
+        $memberInfo = array_merge(...$members->map(fn(RoomMember $member) => [
             $member->getUser()->getUserid() => $member->getPowerLevel(),
-        ])->toArray();
+        ])->toArray());
 
         return [
             'type' => 'm.room.power_levels',


### PR DESCRIPTION
Before this fix, users returned with the power level request were formatted as an associative array within an array. This is now flattened.