### PR TITLE
MDL-81951 changes to power levels

### DIFF
--- a/application/src/Controller/BackOfficeController.php
+++ b/application/src/Controller/BackOfficeController.php
@@ -135,7 +135,11 @@ class BackOfficeController extends AbstractController {
             'rooms' => array_map(function ($room) {
                 $roomdata = $room->jsonSerialize();
                 $roomdata->members = array_map(
-                    fn($membership) => $membership->getUser()->jsonSerialize(),
+                    function (RoomMember $membership) {
+                        $memberdata = $membership->getUser()->jsonSerialize();
+                        $memberdata->powerlevel = $membership->getPowerLevel() ?? 0;
+                        return $memberdata;
+                    },
                     array_filter(
                         $room->getMembers()->toArray(),
                         function (RoomMember $membership): bool {

--- a/application/src/Entity/Room.php
+++ b/application/src/Entity/Room.php
@@ -216,12 +216,18 @@ class Room
         return $roomData;
     }
 
+    protected function getPowerLevelValues(): array
+    {
+        return [
+            'default' => 0,
+            'moderator' => 50,
+            'maximum' => 100,
+        ];
+    }
+
     protected function getPowerLevelState(): array
     {
-        // Power level values.
-        $powerLevelDefault = 0;
-        $powerLevelModerator = 50;
-        $powerLevelMaximum = 100;
+        $powerLevels = $this->getPowerLevelValues();
 
         // Get the members of the room who have a powerlevel set.
         $members = $this->getMembers()->filter(function (RoomMember $member) {
@@ -237,25 +243,48 @@ class Room
             'type' => 'm.room.power_levels',
             'content' => [
                 'users' => (object) $memberInfo,
-                'users_default' => $powerLevelDefault,
+                'users_default' => $powerLevels['default'],
                 'events' => [
-                    'm.room.name' => $powerLevelModerator,
-                    'm.room.power_levels' => $powerLevelMaximum,
-                    'm.room.history_visibility' => $powerLevelMaximum,
-                    'm.room.canonical_alias' => $powerLevelModerator,
-                    'm.room.avatar' => $powerLevelModerator,
-                    'm.room.tombstone' => $powerLevelMaximum,
-                    'm.room.server_acl' => $powerLevelMaximum,
-                    'm.room.encryption' => $powerLevelMaximum,
+                    'm.room.name' => $powerLevels['moderator'],
+                    'm.room.power_levels' => $powerLevels['maximum'],
+                    'm.room.history_visibility' => $powerLevels['maximum'],
+                    'm.room.canonical_alias' => $powerLevels['moderator'],
+                    'm.room.avatar' => $powerLevels['moderator'],
+                    'm.room.tombstone' => $powerLevels['maximum'],
+                    'm.room.server_acl' => $powerLevels['maximum'],
+                    'm.room.encryption' => $powerLevels['maximum'],
                 ],
-                'events_default' =>  $powerLevelDefault,
-                'state_default' => $powerLevelModerator,
-                'ban' => $powerLevelModerator,
-                'kick' => $powerLevelModerator,
-                'redact' => $powerLevelModerator,
-                'invite' =>  $powerLevelDefault,
-                'historical' => $powerLevelMaximum,
+                'events_default' =>  $powerLevels['default'],
+                'state_default' => $powerLevels['moderator'],
+                'ban' => $powerLevels['moderator'],
+                'kick' => $powerLevels['moderator'],
+                'redact' => $powerLevels['moderator'],
+                'invite' =>  $powerLevels['default'],
+                'historical' => $powerLevels['maximum'],
             ],
+        ];
+    }
+
+    public function getPowerLevels(): array
+    {
+        $powerLevels = $this->getPowerLevelValues();
+
+        // Get the members of the room who have a power level set.
+        $members = $this->getMembers()->filter(function (RoomMember $member) {
+            return $member->getPowerLevel() !== null;
+        });
+
+        // Build list of users and their power level.
+        $memberInfo = array_merge(...$members->map(fn(RoomMember $member) => [
+            $member->getUser()->getUserid() => $member->getPowerLevel(),
+        ])->toArray());
+
+        return [
+            'users' => (object) $memberInfo,
+            'ban' => $powerLevels['moderator'],
+            'kick' => $powerLevels['moderator'],
+            'redact' => $powerLevels['moderator'],
+            'invite' =>  $powerLevels['default'],
         ];
     }
 }

--- a/application/src/Entity/Room.php
+++ b/application/src/Entity/Room.php
@@ -259,7 +259,7 @@ class Room
                 'ban' => $powerLevels['moderator'],
                 'kick' => $powerLevels['moderator'],
                 'redact' => $powerLevels['moderator'],
-                'invite' =>  $powerLevels['default'],
+                'invite' =>  $powerLevels['moderator'],
                 'historical' => $powerLevels['maximum'],
             ],
         ];
@@ -284,7 +284,7 @@ class Room
             'ban' => $powerLevels['moderator'],
             'kick' => $powerLevels['moderator'],
             'redact' => $powerLevels['moderator'],
-            'invite' =>  $powerLevels['default'],
+            'invite' =>  $powerLevels['moderator'],
         ];
     }
 }


### PR DESCRIPTION
There are two commits here:
The latest is just a correction to bring our mock's power levels inline with the Matrix defaults.
https://github.com/matrix-org/synapse/blob/v1.70.0/synapse/handlers/room.py#L1170-L1189

The other commit is more substantial. A new GET request is now possible when using the _/v3/rooms/{roomID}/state/{eventType}/_ route that allows the fetching of power levels.

Resolved in **MDL-81591**, we were fetching the power levels using sync, but I found that this would sometimes lag in its results and not always give up-to-the-second results. I created a new trait that used the m.room.power_levels endpoint with a GET request. The changes here reflect that.

**IMPORTANT: This pull request will need to be accepted before the Moodle tracker issue MDL-81951 is integrated.**